### PR TITLE
Update to new API on hooks

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -19,7 +19,7 @@ module.exports = class HandlebarsPrecompile {
     }
 
     apply(compiler) {
-        compiler.plugin('run', (compilation, cb) => {
+        compiler.hooks.run.tapAsync('WebpackHandlebarsPrecompilePlugin', (compiler, cb) => {
             this._cb = cb;
             const {templatesPath, templatesExt, precompileOpts} = this._options;
 


### PR DESCRIPTION
Update to new API on hooks because Tapable.plugin is deprecated